### PR TITLE
fix: conflict with Tzuyu as an avatar and a message

### DIFF
--- a/content/blog/why-does-school-suck-so-much/index.mdx
+++ b/content/blog/why-does-school-suck-so-much/index.mdx
@@ -207,7 +207,7 @@ export const friendProps = {
   username: "Tzuyu",
   roleColor: "green.500",
   date: "2:25 PM",
-  avatar: <Tzuyu />,
+  avatar: <TzuyuAvatar />,
 }
 
 <DiscordMessageContainer mb={6}>

--- a/src/components/Avatars.jsx
+++ b/src/components/Avatars.jsx
@@ -20,21 +20,21 @@ export const avatars = {
       />
     )
   },
-  Tzuyu() {
+  TzuyuAvatar() {
     return (
       <StaticImage
         {...common}
         src="../../content/assets/avatars/tzuyu.png"
-        alt="Tzuyu"
+        alt="Tzuyu Avatar"
       />
     )
   },
-  Jiu() {
+  JiuAvatar() {
     return (
       <StaticImage
         {...common}
         src="../../content/assets/avatars/jiu.png"
-        alt="Kim Minji"
+        alt="Kim Minji Avatar"
       />
     )
   },


### PR DESCRIPTION
Randomly decided to read all of your articles. Noticed some of Tzuyu's messages were blank in [this article](https://xetera.dev/truthiness-equality/). Tried to reach you on Discord from `Niсo#3727` regarding this, but you have DMs disabled. So, I guess I'll fix it myself lol.

This happens because of [an existing component that was named Tzuyu](https://github.com/Xetera/xetera.dev/blob/master/src/components/Avatars.jsx#L23) conflicting with the short-hand [component you created to represent Tzuyu's messages that was *also* named Tzuyu](https://github.com/Xetera/xetera.dev/blob/master/content/blog/truthiness-equality/index.mdx?plain=1#L40). I went ahead and renamed the avatar component for Tzuyu to TzuyuAvatar and did the same for Jiu so that this can be avoided in the future.

For reference, a photo of the issue:

![image](https://user-images.githubusercontent.com/19440022/128454902-f3289202-1de4-4834-b3b7-2b08179b1960.png)
