### PR TITLE
Wrap lanyard on mount so static query doesn't doesn't block

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,6 @@
 import "typeface-sriracha"
 import "typeface-jetbrains-mono"
 import "./static/fonts/wotfard/stylesheet.css"
-import * as React from "react"
-import { wrapRootElement as wrap } from "./src/wrappers/gatsby"
+import { wrapRootElement } from "./src/wrappers/gatsby"
 
-export const wrapRootElement = wrap
+export { wrapRootElement }

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -2,7 +2,7 @@ import React from "react"
 import "typeface-sriracha"
 import "typeface-jetbrains-mono"
 import "./static/fonts/wotfard/stylesheet.css"
-import { wrapRootElement as wrap } from "./src/wrappers/gatsby"
+import { wrapRootElement } from "./src/wrappers/gatsby"
 import { defaultTheme } from "./src/data/providers"
 import { ColorModeScript } from "@chakra-ui/react"
 
@@ -15,4 +15,4 @@ export const onRenderBody = ({ setPreBodyComponents }) => {
   ])
 }
 
-export const wrapRootElement = wrap
+export { wrapRootElement }

--- a/src/components/Lanyard.jsx
+++ b/src/components/Lanyard.jsx
@@ -1,10 +1,25 @@
+import { useStaticQuery, graphql } from "gatsby"
 import React from "react"
 import { LanyardProvider } from "../data/providers"
 import { useLanyard } from "../hooks/lanyard"
 
-const Lanyard = ({ children, discordId }) => {
+const Lanyard = ({ children }) => {
   // stupid gatsby
-  const lanyard = useLanyard(discordId)
+
+  const { site } = useStaticQuery(graphql`
+    query PersistentLayoutQuery {
+      site {
+        siteMetadata {
+          social {
+            discordId
+          }
+        }
+      }
+    }
+  `)
+
+  const lanyard = useLanyard(site.siteMetadata.social.discordId)
+
   return (
     <LanyardProvider.Provider value={lanyard}>
       {children}

--- a/src/components/PersistentLayout.jsx
+++ b/src/components/PersistentLayout.jsx
@@ -1,20 +1,22 @@
-import React from "react"
-import { useState } from "react"
+import React, { useState } from "react"
 import { useMount } from "react-use"
 import Lanyard from "./Lanyard"
 import Navbar from "./Navbar"
 import { Player } from "./Player/Player"
 
-const PersistentLayout = ({ children, data }) => {
+const PersistentLayout = ({ children }) => {
   const [mounted, setMounted] = useState(false)
   useMount(() => setMounted(true))
+
   const PlayerElem = mounted ? Player : "div"
+  const LanyardWrapper = mounted ? Lanyard : "div"
+
   return (
-    <Lanyard discordId={data.siteMetadata.social.discordId}>
+    <LanyardWrapper>
       <Navbar />
       <PlayerElem />
       {children}
-    </Lanyard>
+    </LanyardWrapper>
   )
 }
 

--- a/src/wrappers/gatsby.js
+++ b/src/wrappers/gatsby.js
@@ -1,28 +1,11 @@
-import { graphql, StaticQuery } from "gatsby"
 import React from "react"
 import PersistentLayout from "../components/PersistentLayout"
 import { StyleManager } from "./chakra"
 
 export const wrapRootElement = ({ element }) => {
   return (
-    <StaticQuery
-      query={graphql`
-        query RootWrapperQuery {
-          site {
-            siteMetadata {
-              social {
-                discordId
-                twitter
-              }
-            }
-          }
-        }
-      `}
-      render={data => (
-        <StyleManager>
-          <PersistentLayout data={data.site}>{element}</PersistentLayout>
-        </StyleManager>
-      )}
-    />
+    <StyleManager>
+      <PersistentLayout>{element}</PersistentLayout>
+    </StyleManager>
   )
 }


### PR DESCRIPTION
I've been having so much fun learning all about Gatsby, Chakra, Framer Motion, and more and all kinds of React hooks, etc. I've touched React before but wow, I'm really getting sucked into it this time even now trying to do dependency injection and using RxJS and making hooks for that. Chakra is really awesome, it would save me so much time. Most of my experience is to do all my CSS by hand and I decided on Angular Material for all of our company's UI, and it's really not that great, compared...

The last so many years I've built some huge things with Angular but oh my goodness, I knew it was time to one day actually learn and use React lol. I've been so eager to learn more than ever after I sent my other pr. Learning all these new tools has opened up a whole new world for me. I'm just so happy to learn haha. I've been reading your site's code a lot trying to understand and I'm really intrigued. Thank you so much for inspiring me to try new things I've been scared to touch for a long time.

Anyway, I saw your changes you made adding lanyard (holy crap how cool is this) and I realized it actually broke the rss feed.

If you take a look here: https://xetera.dev/rss.xml
You'll see lots of `Loading (StaticQuery)`'s (aaah)

It took me quite a while but I figured if you add the lanyard context provider wrapper on mount, it seems to fix the problem. I tried all kinds of things reading up on Gatsby PR's and such. I think static queries are generally a bad idea to have in `wrapRootElement` or `wrapPageElement` but if you do them after mount, it should be fine? I'm still learning! I'm not sure. 